### PR TITLE
fixing the version of Tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow-gpu
+tensorflow-gpu==1.14.0
 regex==2017.4.5
 requests==2.21.0
 tqdm==4.31.1


### PR DESCRIPTION
For the safety of the project, it's better to define explicitly the version of all modules we use in it.